### PR TITLE
Ndev 2480 modify plugin for neonlabs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/distribworks/xk6-ethereum
+module github.com/neonlabsorg/xk6-ethereum
 
 go 1.20
 

--- a/module.go
+++ b/module.go
@@ -83,29 +83,29 @@ func (mi *ModuleInstance) NewClient(call sobek.ConstructorCall) *sobek.Object {
 	if opts.Mnemonic != "" {
 		w, err := wallet.NewWalletFromMnemonic(opts.Mnemonic)
 		if err != nil {
-			common.Throw(rt, fmt.Errorf("invalid options; reason: %w", err))
+			common.Throw(rt, fmt.Errorf("Can't get a new wallet from given mnemonic; reason: %w", err))
 		}
 		wa = w
 	} else if opts.PrivateKey != "" {
 		pk, err := hex.DecodeString(opts.PrivateKey)
 		if err != nil {
-			common.Throw(rt, fmt.Errorf("invalid options; reason: %w", err))
+			common.Throw(rt, fmt.Errorf("Can't decode private key; reason: %w", err))
 		}
 		w, err := wallet.NewWalletFromPrivKey(pk)
 		if err != nil {
-			common.Throw(rt, fmt.Errorf("invalid options; reason: %w", err))
+			common.Throw(rt, fmt.Errorf("Can't get a new wallet from given private key; reason: %w", err))
 		}
 		wa = w
 	}
 
 	c, err := jsonrpc.NewClient(opts.URL)
 	if err != nil {
-		common.Throw(rt, fmt.Errorf("invalid options; reason: %w", err))
+		common.Throw(rt, fmt.Errorf("Can't create a new rpc client; reason: %w", err))
 	}
 
 	cid, err := c.Eth().ChainID()
 	if err != nil {
-		common.Throw(rt, fmt.Errorf("invalid options; reason: %w", err))
+		common.Throw(rt, fmt.Errorf("Can't get a chain id; reason: %w", err))
 	}
 
 	client := &Client{

--- a/module.go
+++ b/module.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"math/big"
 	"errors"
 	"fmt"
 	"time"
@@ -102,10 +103,15 @@ func (mi *ModuleInstance) NewClient(call sobek.ConstructorCall) *sobek.Object {
 	if err != nil {
 		common.Throw(rt, fmt.Errorf("Can't create a new rpc client; reason: %w", err))
 	}
-
-	cid, err := c.Eth().ChainID()
-	if err != nil {
-		common.Throw(rt, fmt.Errorf("Can't get a chain id; reason: %w", err))
+	
+	var cid *big.Int
+	if opts.ChainId == nil {
+		cid, err = c.Eth().ChainID()
+		if err != nil {
+			common.Throw(rt, fmt.Errorf("Can't get a chain id; reason: %w", err))
+		}
+	} else {
+		cid = opts.ChainId
 	}
 
 	client := &Client{
@@ -117,7 +123,7 @@ func (mi *ModuleInstance) NewClient(call sobek.ConstructorCall) *sobek.Object {
 		opts:    opts,
 	}
 
-	go client.pollForBlocks()
+	// go client.pollForBlocks()
 
 	return rt.ToValue(client).ToObject(rt)
 }
@@ -153,6 +159,7 @@ type options struct {
 	URL        string `json:"url,omitempty"`
 	Mnemonic   string `json:"mnemonic,omitempty"`
 	PrivateKey string `json:"privateKey,omitempty"`
+	ChainId    *big.Int `json:"chainId,omitempty"`
 }
 
 // newOptionsFrom validates and instantiates an options struct from its map representation

--- a/wallet.go
+++ b/wallet.go
@@ -37,3 +37,21 @@ func (w *Wallet) GenerateKey() (*Key, error) {
 		Address:    k.Address().String(),
 	}, err
 }
+
+func (w *Wallet) NewWalletKeyFromPrivateKey(privateKey []byte) (*Key, error) {
+	wa, err := wallet.NewWalletFromPrivKey(privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	pk, err := wa.MarshallPrivateKey()
+	if err != nil {
+		return nil, err
+	}
+	pks := hex.EncodeToString(pk)
+
+	return &Key{
+		PrivateKey: pks,
+		Address:    wa.Address().String(),
+	}, err
+}


### PR DESCRIPTION
**(add)** a method to create new wallet from private key
**(add)** chainId field to the rpc client struct
**(fix)** bug with dumping metrics
**(fix)** panics on failed requests (getBlockNumber, getBlockByNumber in polling block method, it is background task and we do not need to have a crashed plugin on failed polling)
**(fix)** address format of a "from" field in Transaction structs
